### PR TITLE
Add h0_dyn as an additional profile next to all other profiles

### DIFF
--- a/demandlib/bdew/elec_slp.py
+++ b/demandlib/bdew/elec_slp.py
@@ -14,7 +14,6 @@ import datetime
 import pandas as pd
 import os
 import calendar
-import warnings
 
 from demandlib.tools import add_weekdays2df
 

--- a/demandlib/examples/power_demand_example.py
+++ b/demandlib/examples/power_demand_example.py
@@ -53,6 +53,7 @@ def power_example(
         ann_el_demand_per_sector = {
             'g0': 3000,
             'h0': 3000,
+            'h0_dyn': 3000,
             'i0': 3000,
             'i1': 5000,
             'i2': 6000,
@@ -63,8 +64,7 @@ def power_example(
     e_slp = bdew.ElecSlp(year, holidays=holidays)
 
     # multiply given annual demand with timeseries
-    elec_demand = e_slp.get_profile(ann_el_demand_per_sector,
-                                    dyn_function_h0=False)
+    elec_demand = e_slp.get_profile(ann_el_demand_per_sector)
 
     # Add the slp for the industrial group
     ilp = profiles.IndustrialLoadProfile(e_slp.date_time_index,


### PR DESCRIPTION
I think we do not need a decision parameter, because we can just add `h0_dyn` as  an additional profile. 

It is also faster that way, because the profiles can be used for different annual values very fast instead of calculating the profile ever again.

Furthermore, the creation of the dynamic profile is 1000 time faster now (<0.01 sec).

