### PR TITLE
Changed heat_building.py to include checks for non-residential shlp_type

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -4,6 +4,7 @@ Authors
 
 (alphabetic order)
 
+ * Amedeo Ceruti
  * Birgit Schachler
  * Caroline Möller
  * Guido Plessmann

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,11 +10,13 @@ New features
 
 Bug fixes
 #########
-*   
+*   Raise error for non supported shlp_type 
+	in non-commercial buildings
 
 Other changes
 #############
 *   Adhere to packaging standards
+* 	Raise errors in sigmoid parameter queries
 
 
 v0.1.9 (2023-03-18)

--- a/src/demandlib/bdew/heat_building.py
+++ b/src/demandlib/bdew/heat_building.py
@@ -296,7 +296,7 @@ class HeatBuilding:
         b = sigmoid["parameter_b"].iloc[0]
         c = sigmoid["parameter_c"].iloc[0]
         if self.ww_incl:
-            d = float(sigmoid["parameter_d"].iloc[0])
+            d = sigmoid["parameter_d"].iloc[0]
         else:
             d = 0
         return a, b, c, d

--- a/src/demandlib/bdew/heat_building.py
+++ b/src/demandlib/bdew/heat_building.py
@@ -292,9 +292,9 @@ class HeatBuilding:
                     )
 
         # get sigmoid parameters, avoid warning
-        a = float(sigmoid["parameter_a"].iloc[0])
-        b = float(sigmoid["parameter_b"].iloc[0])
-        c = float(sigmoid["parameter_c"].iloc[0])
+        a = sigmoid["parameter_a"].iloc[0]
+        b = sigmoid["parameter_b"].iloc[0]
+        c = sigmoid["parameter_c"].iloc[0]
         if self.ww_incl:
             d = float(sigmoid["parameter_d"].iloc[0])
         else:

--- a/src/demandlib/bdew/heat_building.py
+++ b/src/demandlib/bdew/heat_building.py
@@ -274,23 +274,21 @@ class HeatBuilding:
             + "wind_impact=={0}".format(self.wind_class)
         )
 
-        # check if it finds sigmoid parameters
+        wrong_number_of_parameters_message = (
+            "{number} sigmoid parameters found for "
+            + f"building_class={self.building_class}, shlp_type={self.shlp_type}, "
+            + f"wind_class={self.wind_class}"
+        )
         if len(sigmoid) == 0:
             raise ValueError(
-                "No sigmoid parameters found for "
-                + "building_class={0}, shlp_type={1}, wind_class={2}".format(
-                    self.building_class, self.shlp_type, self.wind_class
+                wrong_number_of_parameters_message.format("No")
                 )
-            )
 
         # check if it finds only one row of sigmoid parameters
         if len(sigmoid) > 1:
             raise ValueError(
-                "Multiple sigmoid parameters found for "
-                + "building_class={0}, shlp_type={1}, wind_class={2}".format(
-                    self.building_class, self.shlp_type, self.wind_class
-                )
-            )
+                    wrong_number_of_parameters_message.format("Multiple")
+                    )
 
         # get sigmoid parameters, avoid warning
         a = float(sigmoid["parameter_a"].iloc[0])

--- a/src/demandlib/bdew/heat_building.py
+++ b/src/demandlib/bdew/heat_building.py
@@ -275,10 +275,11 @@ class HeatBuilding:
         )
 
         wrong_number_of_parameters_message = (
-            "{number} sigmoid parameters found for "
+            "{} sigmoid parameters found for "
             + f"building_class={self.building_class}, shlp_type={self.shlp_type}, "
             + f"wind_class={self.wind_class}"
         )
+
         if len(sigmoid) == 0:
             raise ValueError(
                 wrong_number_of_parameters_message.format("No")

--- a/src/demandlib/bdew/heat_building.py
+++ b/src/demandlib/bdew/heat_building.py
@@ -274,11 +274,30 @@ class HeatBuilding:
             + "wind_impact=={0}".format(self.wind_class)
         )
 
-        a = float(sigmoid["parameter_a"])
-        b = float(sigmoid["parameter_b"])
-        c = float(sigmoid["parameter_c"])
+        # check if it finds sigmoid parameters
+        if len(sigmoid) == 0:
+            raise ValueError(
+                "No sigmoid parameters found for "
+                + "building_class={0}, shlp_type={1}, wind_class={2}".format(
+                    self.building_class, self.shlp_type, self.wind_class
+                )
+            )
+
+        # check if it finds only one row of sigmoid parameters
+        if len(sigmoid) > 1:
+            raise ValueError(
+                "Multiple sigmoid parameters found for "
+                + "building_class={0}, shlp_type={1}, wind_class={2}".format(
+                    self.building_class, self.shlp_type, self.wind_class
+                )
+            )
+
+        # get sigmoid parameters, avoid warning
+        a = float(sigmoid["parameter_a"].iloc[0])
+        b = float(sigmoid["parameter_b"].iloc[0])
+        c = float(sigmoid["parameter_c"].iloc[0])
         if self.ww_incl:
-            d = float(sigmoid["parameter_d"])
+            d = float(sigmoid["parameter_d"].iloc[0])
         else:
             d = 0
         return a, b, c, d

--- a/src/demandlib/bdew/heat_building.py
+++ b/src/demandlib/bdew/heat_building.py
@@ -64,7 +64,7 @@ class HeatBuilding:
         self.wind_class = kwargs.get("wind_class")
         self.building_class = kwargs.get("building_class", 0)
         # raise error if building class is not 0 for non-residential buildings
-        if (self.shlp_type not in ["EFH", "MFH"]) & (self.building_class != 0):
+        if (self.shlp_type not in ["EFH", "MFH"]) and (self.building_class != 0):
             raise ValueError(
                 "Building class must be 0 for non-residential buildings"
                 )
@@ -277,19 +277,14 @@ class HeatBuilding:
         wrong_number_of_parameters_message = (
             "{} sigmoid parameters found for "
             + f"building_class={self.building_class}, shlp_type={self.shlp_type}, "
-            + f"wind_class={self.wind_class}"
+            + f"wind_class={self.wind_class}. Should be 1."
         )
 
-        if len(sigmoid) == 0:
+        # check if it does not find one row of sigmoid parameters
+        if len(sigmoid) != 1:
             raise ValueError(
-                wrong_number_of_parameters_message.format("No")
+                wrong_number_of_parameters_message.format(len(sigmoid))
                 )
-
-        # check if it finds only one row of sigmoid parameters
-        if len(sigmoid) > 1:
-            raise ValueError(
-                    wrong_number_of_parameters_message.format("Multiple")
-                    )
 
         # get sigmoid parameters, avoid warning
         a = sigmoid["parameter_a"].iloc[0]

--- a/src/demandlib/bdew/heat_building.py
+++ b/src/demandlib/bdew/heat_building.py
@@ -36,8 +36,9 @@ class HeatBuilding:
     annual_heat_demand : float
         annual heat demand of building in kWh
     building_class: int
-        class of building according to bdew classification
-        possible numbers are: 1 - 11
+        class of building according to bdew classification:
+        possible numbers for EFH and MFH are: 1 - 11.
+        Possible numbers for non-residential buildings are: 0.
     shlp_type : string
         type of standardized heat load profile according to bdew
         possible types are:
@@ -62,6 +63,11 @@ class HeatBuilding:
         self.shlp_type = kwargs.get("shlp_type").upper()
         self.wind_class = kwargs.get("wind_class")
         self.building_class = kwargs.get("building_class", 0)
+        # raise error if building class is not 0 for non-residential buildings
+        if (self.shlp_type not in ["EFH", "MFH"]) & (self.building_class != 0):
+            raise ValueError(
+                "Building class must be 0 for non-residential buildings"
+                )
         self.ww_incl = kwargs.get("ww_incl", True)
         self.name = kwargs.get("name", self.shlp_type)
 


### PR DESCRIPTION
* Added a ValueError to catch unwanted error downstream
 
Now the non residential buildings will throw a ValueError to avoid non supported integers in the database located in `src/demandlib/bdew/bdew_data`. This made the function `heat_building.get_sigmoid_parameters` return an empty list if `self.shlp_type` was not 0 for non-commercial buildings.
Updated the documentation of the class `HeatBuilding` to reflect the needed input data too.


