### PR TITLE
Fix FutureWarnings

### DIFF
--- a/src/demandlib/bdew/elec_slp.py
+++ b/src/demandlib/bdew/elec_slp.py
@@ -114,15 +114,15 @@ class ElecSlp:
             new_df, holidays=holidays, holiday_is_sunday=True
         )
 
-        new_df["hour"] = dt_index.hour.astype(float)
+        new_df["hour"] = dt_index.hour.astype(int)
         new_df["weekday"] = new_df["weekday"].astype(int)
-        new_df["minute"] = dt_index.minute.astype(float)
+        new_df["minute"] = dt_index.minute.astype(int)
         time_df = new_df[["date", "hour", "minute", "weekday"]].copy()
         tmp_df[slp_types] = tmp_df[slp_types].astype(float)
 
         # Inner join the slps on the time_df to the slp's for a whole year
-        tmp_df["hour_of_day"] = tmp_df.index.hour.astype(float)
-        tmp_df["minute_of_hour"] = tmp_df.index.minute.astype(float)
+        tmp_df["hour_of_day"] = tmp_df.index.hour
+        tmp_df["minute_of_hour"] = tmp_df.index.minute
         left_cols = ["hour_of_day", "minute_of_hour", "weekday"]
         right_cols = ["hour", "minute", "weekday"]
         tmp_df = tmp_df.reset_index(drop=True)
@@ -205,3 +205,4 @@ class ElecSlp:
             ).dropna(how="all", axis=1)
             * 4
         )
+ 

--- a/src/demandlib/bdew/elec_slp.py
+++ b/src/demandlib/bdew/elec_slp.py
@@ -109,19 +109,20 @@ class ElecSlp:
         tmp_df.set_index(index, inplace=True)
 
         # Create empty DataFrame to take the results.
-        new_df = pd.DataFrame(index=dt_index, columns=slp_types).fillna(0)
+        new_df = pd.DataFrame(index=dt_index, columns=slp_types, dtype=float).fillna(0)
         new_df = add_weekdays2df(
             new_df, holidays=holidays, holiday_is_sunday=True
         )
 
-        new_df["hour"] = dt_index.hour
-        new_df["minute"] = dt_index.minute
+        new_df["hour"] = dt_index.hour.astype(float)
+        new_df["weekday"] = new_df["weekday"].astype(int)
+        new_df["minute"] = dt_index.minute.astype(float)
         time_df = new_df[["date", "hour", "minute", "weekday"]].copy()
         tmp_df[slp_types] = tmp_df[slp_types].astype(float)
 
         # Inner join the slps on the time_df to the slp's for a whole year
-        tmp_df["hour_of_day"] = tmp_df.index.hour
-        tmp_df["minute_of_hour"] = tmp_df.index.minute
+        tmp_df["hour_of_day"] = tmp_df.index.hour.astype(float)
+        tmp_df["minute_of_hour"] = tmp_df.index.minute.astype(float)
         left_cols = ["hour_of_day", "minute_of_hour", "weekday"]
         right_cols = ["hour", "minute", "weekday"]
         tmp_df = tmp_df.reset_index(drop=True)

--- a/src/demandlib/tools.py
+++ b/src/demandlib/tools.py
@@ -44,6 +44,6 @@ def add_weekdays2df(time_df, holidays=None, holiday_is_sunday=False):
         )
 
     if holiday_is_sunday:
-        time_df.weekday.mask(cond=time_df.weekday == 0, other=7, inplace=True)
+        time_df.weekday = time_df.weekday.mask(cond=time_df.weekday == 0, other=7)
 
     return time_df


### PR DESCRIPTION
**To Reproduce**
The following snippet produces warnings using python 3.11 and pandas 2.2.1

```
from demandlib.bdew import ElecSlp
e_slp = ElecSlp(2019)
```

demandlib had some pandas warnings:
* `FutureWarning: Downcasting object dtype arrays on .fillna, .ffill, .bfill is deprecated and will change in a future version`
* `FutureWarning: Setting an item of incompatible dtype is deprecated and will raise in a future error of pandas`
* `FutureWarning: A value is trying to be set on a copy of a DataFrame or Series through chained assignment using an inplace method`

These are fixed through this commit.