### PR TITLE
Update actions and python CI

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -25,7 +25,7 @@ If applicable, add screenshots to help explain your problem.
 
 **Desktop (please complete the following information):**
  - OS: [e.g. iOS, Debian, Ubuntu, Windows10]
- - Python version [e.g. 3.8]
+ - Python version [e.g. 3.11]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.11
 
       - name: Install Python dependencies
         run: pip install black flake8

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
 
@@ -26,7 +26,7 @@ jobs:
         run: pip install black flake8
 
       - name: Run linters
-        uses: samuelmeuli/lint-action@v1
+        uses: wearerequired/lint-action@v2
         with:
           github_token: ${{ secrets.github_token }}
           # Enable linters

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.9]
+        python-version: [3.11]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -19,9 +19,9 @@ jobs:
         python-version: [3.9]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -31,7 +31,7 @@ jobs:
       run: python setup.py sdist bdist_wheel
     - name: Run twine check
       run: twine check dist/*
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: tox-gh-actions-dist
         path: dist

--- a/.github/workflows/tox_checks.yml
+++ b/.github/workflows/tox_checks.yml
@@ -29,12 +29,12 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up Python ${{ env.default_python || '3.9' }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: "${{ env.default_python || '3.9' }}"
 
       - name: Pip cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ matrix.toxenv }}-${{ hashFiles('tox.ini', 'setup.py') }}

--- a/.github/workflows/tox_checks.yml
+++ b/.github/workflows/tox_checks.yml
@@ -28,10 +28,10 @@ jobs:
       - name: Git clone
         uses: actions/checkout@v2
 
-      - name: Set up Python ${{ env.default_python || '3.9' }}
+      - name: Set up Python ${{ env.default_python || '3.11' }}
         uses: actions/setup-python@v5
         with:
-          python-version: "${{ env.default_python || '3.9' }}"
+          python-version: "${{ env.default_python || '3.11' }}"
 
       - name: Pip cache
         uses: actions/cache@v4

--- a/.github/workflows/tox_pytests.yml
+++ b/.github/workflows/tox_pytests.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ["3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/tox_pytests.yml
+++ b/.github/workflows/tox_pytests.yml
@@ -19,11 +19,11 @@ jobs:
         python-version: [3.7, 3.8, 3.9]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Install xmllint
       run: sudo apt install coinor-cbc
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -7,6 +7,7 @@ Authors
  * Amedeo Ceruti
  * Birgit Schachler
  * Caroline Möller
+ * Florian Maurer
  * Guido Plessmann
  * Hendrik Huyskens
  * Jann Launer

--- a/tox.ini
+++ b/tox.ini
@@ -3,19 +3,18 @@ envlist =
     clean,
     check,
     docs,
-    py36
-    py37
-    py38
     py39
+    py310
+    py311
     py3-cover,
     pypy3,
     report
 
 [gh-actions]
 python =
-    3.7: py37
-    3.8: py38
     3.9: py39
+    3.10: py310
+    3.11: py311
 
 [testenv]
 basepython =
@@ -83,41 +82,30 @@ commands = coverage erase
 skip_install = true
 deps = coverage
 
-[testenv:py36]
-basepython = {env:TOXPYTHON:python3.6}
-setenv =
-    {[testenv]setenv}
-usedevelop = true
-commands =
-    {posargs:pytest --cov --cov-report=term-missing -vv}
-deps =
-    {[testenv]deps}
-    pytest-cov
-
-[testenv:py37]
-basepython = {env:TOXPYTHON:python3.7}
-setenv =
-    {[testenv]setenv}
-usedevelop = true
-commands =
-    {posargs:pytest --cov --cov-report=term-missing -vv}
-deps =
-    {[testenv]deps}
-    pytest-cov
-
-[testenv:py38]
-basepython = {env:TOXPYTHON:python3.8}
-setenv =
-    {[testenv]setenv}
-usedevelop = true
-commands =
-    {posargs:pytest --cov --cov-report=term-missing -vv}
-deps =
-    {[testenv]deps}
-    pytest-cov
-
 [testenv:py39]
 basepython = {env:TOXPYTHON:python3.9}
+setenv =
+    {[testenv]setenv}
+usedevelop = true
+commands =
+    {posargs:pytest --cov --cov-report=term-missing -vv}
+deps =
+    {[testenv]deps}
+    pytest-cov
+
+[testenv:py310]
+basepython = {env:TOXPYTHON:python3.10}
+setenv =
+    {[testenv]setenv}
+usedevelop = true
+commands =
+    {posargs:pytest --cov --cov-report=term-missing -vv}
+deps =
+    {[testenv]deps}
+    pytest-cov
+
+[testenv:py311]
+basepython = {env:TOXPYTHON:python3.11}
 setenv =
     {[testenv]setenv}
 usedevelop = true


### PR DESCRIPTION
This updates the runner actions to not use deprecated node versions.
The CI python versions are updated to use 3.9, 3.10 and 3.11

Nothing should break from this.
This worked for me, running `tox` in a fresh env for demandlib