### PR TITLE
Revert 2500bf7 for the pandas masking function

### DIFF
--- a/src/demandlib/particular_profiles.py
+++ b/src/demandlib/particular_profiles.py
@@ -62,21 +62,25 @@ class IndustrialLoadProfile:
 
         self.dataframe["ind"] = 0
 
-        self.dataframe["ind"] = self.dataframe["ind"].mask(
+        self.dataframe["ind"].mask(
             cond=self.dataframe["weekday"].between_time(am, pm).isin(week),
             other=profile_factors["week"]["day"],
+            inplace=True,
         )
-        self.dataframe["ind"] = self.dataframe["ind"].mask(
+        self.dataframe["ind"].mask(
             cond=self.dataframe["weekday"].between_time(pm, am).isin(week),
             other=profile_factors["week"]["night"],
+            inplace=True,
         )
-        self.dataframe["ind"] = self.dataframe["ind"].mask(
+        self.dataframe["ind"].mask(
             cond=self.dataframe["weekday"].between_time(am, pm).isin(weekend),
             other=profile_factors["weekend"]["day"],
+            inplace=True,
         )
-        self.dataframe["ind"] = self.dataframe["ind"].mask(
+        self.dataframe["ind"].mask(
             cond=self.dataframe["weekday"].between_time(pm, am).isin(weekend),
             other=profile_factors["weekend"]["night"],
+            inplace=True,
         )
 
         if self.dataframe["ind"].isnull().any(axis=0):


### PR DESCRIPTION
When loading a simple_profile from the IndustrialLoadProfile class in demandlib version 0.2.0, the outcome differs from what was observed in version 0.1.9. Reverting commit https://github.com/oemof/demandlib/commit/2500bf74f0c9f47afc9e62424fd869292745c221 in src/demandlib/particular_profiles.py may resolve this issue. 

This should solve issue #64.