### PR TITLE
fix between_time filtering values

### DIFF
--- a/src/demandlib/particular_profiles.py
+++ b/src/demandlib/particular_profiles.py
@@ -60,22 +60,28 @@ class IndustrialLoadProfile:
 
         profile_factors = kwargs.get("profile_factors", default_factors)
 
-        self.dataframe["ind"] = 0
+        self.dataframe["ind"] = 0.0
+        day_mask = self.dataframe.index.indexer_between_time(am, pm)
+        night_mask = self.dataframe.index.indexer_between_time(pm, am)
+        day_filter = pd.Series(False, index=self.dataframe.index)
+        day_filter.iloc[day_mask] = True
+        night_filter = pd.Series(False, index=self.dataframe.index)
+        night_filter.iloc[night_mask] = True
 
         self.dataframe["ind"] = self.dataframe["ind"].mask(
-            cond=self.dataframe["weekday"].between_time(am, pm).isin(week),
+            cond=day_filter & self.dataframe["weekday"].isin(week),
             other=profile_factors["week"]["day"],
         )
         self.dataframe["ind"] = self.dataframe["ind"].mask(
-            cond=self.dataframe["weekday"].between_time(pm, am).isin(week),
+            cond=night_filter & self.dataframe["weekday"].isin(week),
             other=profile_factors["week"]["night"],
         )
         self.dataframe["ind"] = self.dataframe["ind"].mask(
-            cond=self.dataframe["weekday"].between_time(am, pm).isin(weekend),
+            cond=day_filter & self.dataframe["weekday"].isin(weekend),
             other=profile_factors["weekend"]["day"],
         )
         self.dataframe["ind"] = self.dataframe["ind"].mask(
-            cond=self.dataframe["weekday"].between_time(pm, am).isin(weekend),
+            cond=night_filter & self.dataframe["weekday"].isin(weekend),
             other=profile_factors["weekend"]["night"],
         )
 

--- a/src/demandlib/particular_profiles.py
+++ b/src/demandlib/particular_profiles.py
@@ -68,22 +68,14 @@ class IndustrialLoadProfile:
         night_filter = pd.Series(False, index=self.dataframe.index)
         night_filter.iloc[night_mask] = True
 
-        self.dataframe["ind"] = self.dataframe["ind"].mask(
-            cond=day_filter & self.dataframe["weekday"].isin(week),
-            other=profile_factors["week"]["day"],
-        )
-        self.dataframe["ind"] = self.dataframe["ind"].mask(
-            cond=night_filter & self.dataframe["weekday"].isin(week),
-            other=profile_factors["week"]["night"],
-        )
-        self.dataframe["ind"] = self.dataframe["ind"].mask(
-            cond=day_filter & self.dataframe["weekday"].isin(weekend),
-            other=profile_factors["weekend"]["day"],
-        )
-        self.dataframe["ind"] = self.dataframe["ind"].mask(
-            cond=night_filter & self.dataframe["weekday"].isin(weekend),
-            other=profile_factors["weekend"]["night"],
-        )
+        week_filter = self.dataframe["weekday"].isin(week)
+        weekend_filter = self.dataframe["weekday"].isin(weekend)
+
+        # Update 'ind' column based on day/night filters and weekday/weekend conditions
+        self.dataframe.loc[day_filter & week_filter, "ind"] = profile_factors["week"]["day"]
+        self.dataframe.loc[night_filter & week_filter, "ind"] = profile_factors["week"]["night"]
+        self.dataframe.loc[day_filter & weekend_filter, "ind"] = profile_factors["weekend"]["day"]
+        self.dataframe.loc[night_filter & weekend_filter, "ind"] = profile_factors["weekend"]["night"]
 
         if self.dataframe["ind"].isnull().any(axis=0):
             logging.error("NAN value found in industrial load profile")


### PR DESCRIPTION
Set masked values on parts with `indexer_between_time` to keep the values not in the time with false.
This is actually unrelated to the mask having an error but comes from between_time returning only a subset of the data, which makes pandas loose the other parts of the index.

fixes #64 
supersedes #65 

I am not particular happy with this solution, but it includes not having errors and not producing warnings
