### PR TITLE
Feature/holidays in industrial profile

### DIFF
--- a/docs/further_profiles.rst
+++ b/docs/further_profiles.rst
@@ -10,7 +10,36 @@ Industrial Electrical Profile
 Description
 +++++++++++
 
-The industrial electrical profile uses a step function.
+The industrial electrical profile uses a step function synthesized using different
+scaling factors for weekdays, weekend days and holidays as well as day time and night
+time.
 
 Usage
 +++++
+The industrial profile is explained in the example `electricity_demand_example.py`
+located in the examples directory of the repository.
+
+.. code-block:: python
+    import datetime
+    import demandlib.particular_profiles as profiles
+    import pandas as pd
+
+    holidays = {
+        datetime.date(2018, 1, 1): "New year",
+    }
+    # Set up IndustrialLoadProfile
+    ilp = profiles.IndustrialLoadProfile(
+        dt_index=pd.date_range("01-01-2018", "01-01-2019", freq="15min"),
+        holidays=holidays
+    )
+    # Get step load profile with own scaling factors and definition of
+    # beginning of workday
+    ind_elec_demand = ilp.simple_profile(
+        annual_demand=1e4,
+        am=datetime.time(9, 0, 0),
+        profile_factors={
+            "week": {"day": 1.0, "night": 0.8},
+            "weekend": {"day": 0.8, "night": 0.6},
+            "holiday": {"day": 0.2, "night": 0.2},
+        },
+    )

--- a/docs/further_profiles.rst
+++ b/docs/further_profiles.rst
@@ -20,6 +20,7 @@ The industrial profile is explained in the example `electricity_demand_example.p
 located in the examples directory of the repository.
 
 .. code-block:: python
+
     import datetime
     import demandlib.particular_profiles as profiles
     import pandas as pd

--- a/examples/electricity_demand_example.py
+++ b/examples/electricity_demand_example.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """
-Creating power demand profiles using BDEW profiles for residential, commercial and
-agricultural loads, as well as step load profiles for industrial loads.
+Creating power demand profiles using BDEW profiles for residential, commercial
+and agricultural loads, as well as step load profiles for industrial loads.
 
 Installation requirements
 -------------------------

--- a/examples/electricity_demand_example.py
+++ b/examples/electricity_demand_example.py
@@ -82,6 +82,7 @@ elec_demand["i2"] = ilp.simple_profile(
     profile_factors={
         "week": {"day": 1.0, "night": 0.8},
         "weekend": {"day": 0.8, "night": 0.6},
+        "holiday": {"day": 0.6, "night": 0.4},
     },
 )
 

--- a/examples/electricity_demand_example.py
+++ b/examples/electricity_demand_example.py
@@ -1,13 +1,14 @@
 # -*- coding: utf-8 -*-
 """
-Creating power demand profiles using bdew profiles.
+Creating power demand profiles using BDEW profiles for residential, commercial and
+agricultural loads, as well as step load profiles for industrial loads.
 
 Installation requirements
 -------------------------
 This example requires at least version v0.1.4 of the oemof demandlib. Install
 by:
     pip install 'demandlib>=0.1.4,<0.2'
-Optional:
+It further requires matplotlib for plotting:
     pip install matplotlib
 
 SPDX-FileCopyrightText: Birgit Schachler
@@ -85,16 +86,16 @@ elec_demand["i2"] = ilp.simple_profile(
 )
 
 print(
-    "Be aware that the values in the DataFrame are 15 minute values"
-    + "with a power unit. If you sum up a table with 15min values"
-    + "the result will be of the unit 'kW15minutes'."
+    "Be aware that the values in the DataFrame are 15 minute values "
+    "with a power unit. If you sum up a table with 15min values "
+    "the result will be of the unit 'kW15minutes'."
 )
 print(elec_demand.sum())
 
 print("You will have to divide the result by 4 to get kWh.")
 print(elec_demand.sum() / 4)
 
-print("Or resample the DataFrame to hourly values using the mean() " "method.")
+print("Or resample the DataFrame to hourly values using the mean() method.")
 
 # Resample 15-minute values to hourly values.
 elec_demand_resampled = elec_demand.resample("h").mean()

--- a/src/demandlib/particular_profiles.py
+++ b/src/demandlib/particular_profiles.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Implementation of the bdew standard load profiles for electric power.
+Implementation of industrial step load profiles.
 
 
 """
@@ -13,9 +13,30 @@ from .tools import add_weekdays2df
 
 
 class IndustrialLoadProfile:
-    """Generate an industrial heat or electric load profile."""
+    """Generate an industrial heat or electricity load profile."""
 
     def __init__(self, dt_index, holidays=None, holiday_is_sunday=False):
+        """
+        Initialize the industrial load profile.
+
+        Parameters
+        ----------
+        dt_index : pandas.DatetimeIndex
+            Datetime index for the load profile.
+        holidays : dict
+            Dictionary with keys of type datetime and values with holiday name as str,
+            e.g. {datetime.date(2010, 1, 1): "New year"}. See the
+            electricity_demand_example in the examples directory for information on
+            how to obtain holidays using workalender. Per default, no holidays are
+            used.
+            Default: None.
+        holiday_is_sunday : bool
+            If True, holidays are treated as Sundays. If False, holidays are assigned
+            weekday 0 and separate holiday scaling factors are applied in method
+            simple_profile().
+            Default: False.
+
+        """
         self.dataframe = pd.DataFrame(index=dt_index)
         self.dataframe = add_weekdays2df(
             self.dataframe,
@@ -25,26 +46,60 @@ class IndustrialLoadProfile:
 
     def simple_profile(self, annual_demand, **kwargs):
         """
-        Create industrial load profile
+        Create industrial step load profile.
 
         Parameters
         ----------
         annual_demand : float
-            Total demand.
+            Total demand over the period given upon initialisation
+            of IndustrialLoadProfile through parameter `dt_index`. This is actually
+            only the annual demand, if an entire year was given.
 
         Other Parameters
         ----------------
         am : datetime.time
-            beginning of workday
+            Defines the beginning of the workday. Times between `am` and `pm`, including
+            the start and end time defined by `am` and `pm`, are assigned "day" factors
+            from `profile_factors`. Other times are assigned "night" factors.
+            Default: 7 a.m.
         pm : datetime.time
-            end of workday
-        week : list
-            list of weekdays
-        weekend : list
-            list of weekend days
-        profile_factors : dictionary
-            dictionary with scaling factors for night and day of weekdays and
-            weekend days
+            Defines the end of the workday. Times between `am` and `pm`, including
+            the start and end time defined by `am` and `pm`, are assigned "day" factors
+            from `profile_factors`. Other times are assigned "night" factors.
+            Default: 11:30 p.m.
+        week : list(int)
+            List of weekdays, where 1 corresponds to Monday, 2 to Tuesday, etc.
+            Weekdays are assigned "week" factors from `profile_factors`.
+            Default: [1, 2, 3, 4, 5].
+        weekend : list(int)
+            List of weekend days, where 1 corresponds to Monday, 2 to Tuesday, etc.
+            Weekend days are assigned "weekend" factors from `profile_factors`.
+            Default: [6, 7].
+        holiday : list(int)
+            List of holiday days. Holidays given upon initialisation of the
+            IndustrialLoadProfile object are tagged with weekday 0 if
+            `holiday_is_sunday` is set to False, wherefore the default for this
+            parameter is [0].
+            Holidays are assigned "holiday" factors from `profile_factors`.
+            Default: [0].
+        profile_factors : dict
+            Dictionary with load profile scaling factors for night and day of weekdays,
+            weekend days and holidays. The dictionary must have the same form as the
+            dictionary given as the default value.
+            Default:
+            {
+                "week": {"day": 0.8, "night": 0.6},
+                "weekend": {"day": 0.9, "night": 0.7},
+                "holiday": {"day": 0.9, "night": 0.7},
+            }
+
+        Returns
+        -------
+        pd.Series
+            Series with demand per time step (unit depends on the unit the
+            `annual_demand` was provided with). Index is a DatetimeIndex containing
+            all time steps the IndustrialLoadProfile was initialised with.
+
         """
 
         # Define day (am to pm), night (pm to am), week day (week),
@@ -103,6 +158,7 @@ class IndustrialLoadProfile:
         self.dataframe.loc[night_filter & holiday_filter, "ind"] = \
             profile_factors["holiday"]["night"]
 
+        # Check for NAN values in the dataframe
         if self.dataframe["ind"].isnull().any(axis=0):
             logging.error("NAN value found in industrial load profile")
 

--- a/src/demandlib/particular_profiles.py
+++ b/src/demandlib/particular_profiles.py
@@ -4,7 +4,6 @@ Implementation of industrial step load profiles.
 
 
 """
-import logging
 from datetime import time as settime
 
 import pandas as pd

--- a/src/demandlib/particular_profiles.py
+++ b/src/demandlib/particular_profiles.py
@@ -88,20 +88,16 @@ class IndustrialLoadProfile:
         weekend_filter = self.dataframe["weekday"].isin(weekend)
         holiday_filter = self.dataframe["weekday"].isin(holiday)
 
-        # Update 'ind' column based on day/night filters
-        # and weekday/weekend conditions.
-        self.dataframe.loc[day_filter & week_filter, "ind"] = profile_factors[
-            "week"
-        ]["day"]
-        self.dataframe.loc[night_filter & week_filter, "ind"] = (
+        # Update 'ind' column based on day/night filters and weekday/weekend/holiday
+        # conditions
+        self.dataframe.loc[day_filter & week_filter, "ind"] = \
+            profile_factors["week"]["day"]
+        self.dataframe.loc[night_filter & week_filter, "ind"] = \
             profile_factors["week"]["night"]
-        )
-        self.dataframe.loc[day_filter & weekend_filter, "ind"] = (
+        self.dataframe.loc[day_filter & weekend_filter, "ind"] = \
             profile_factors["weekend"]["day"]
-        )
-        self.dataframe.loc[night_filter & weekend_filter, "ind"] = (
+        self.dataframe.loc[night_filter & weekend_filter, "ind"] = \
             profile_factors["weekend"]["night"]
-        )
         self.dataframe.loc[day_filter & holiday_filter, "ind"] = \
             profile_factors["holiday"]["day"]
         self.dataframe.loc[night_filter & holiday_filter, "ind"] = \

--- a/src/demandlib/particular_profiles.py
+++ b/src/demandlib/particular_profiles.py
@@ -159,18 +159,24 @@ class IndustrialLoadProfile:
 
         # Update 'ind' column based on day/night filters and
         # weekday/weekend/holiday conditions
-        self.dataframe.loc[day_filter & week_filter, "ind"] = \
-            profile_factors["week"]["day"]
-        self.dataframe.loc[night_filter & week_filter, "ind"] = \
+        self.dataframe.loc[day_filter & week_filter, "ind"] = profile_factors[
+            "week"
+        ]["day"]
+        self.dataframe.loc[night_filter & week_filter, "ind"] = (
             profile_factors["week"]["night"]
-        self.dataframe.loc[day_filter & weekend_filter, "ind"] = \
+        )
+        self.dataframe.loc[day_filter & weekend_filter, "ind"] = (
             profile_factors["weekend"]["day"]
-        self.dataframe.loc[night_filter & weekend_filter, "ind"] = \
+        )
+        self.dataframe.loc[night_filter & weekend_filter, "ind"] = (
             profile_factors["weekend"]["night"]
-        self.dataframe.loc[day_filter & holiday_filter, "ind"] = \
+        )
+        self.dataframe.loc[day_filter & holiday_filter, "ind"] = (
             profile_factors["holiday"]["day"]
-        self.dataframe.loc[night_filter & holiday_filter, "ind"] = \
+        )
+        self.dataframe.loc[night_filter & holiday_filter, "ind"] = (
             profile_factors["holiday"]["night"]
+        )
 
         # Check for NAN values in the dataframe
         if self.dataframe["ind"].isnull().any(axis=0):

--- a/src/demandlib/particular_profiles.py
+++ b/src/demandlib/particular_profiles.py
@@ -123,17 +123,17 @@ class IndustrialLoadProfile:
         profile_factors = kwargs.get("profile_factors", default_factors)
         # check profile factors
         for key in ["week", "weekend", "holiday"]:
-            if not key in profile_factors.keys():
+            if key not in profile_factors.keys():
                 raise ValueError(
                     f"Missing entry for '{key}' in profile_factors."
                 )
             else:
-                if not "day" in profile_factors[key].keys():
+                if "day" not in profile_factors[key].keys():
                     raise ValueError(
                         f"Missing entry for 'day' in profile_factors for "
                         f"'{key}'."
                     )
-                elif not "night" in profile_factors[key].keys():
+                elif "night" not in profile_factors[key].keys():
                     raise ValueError(
                         f"Missing entry for 'night' in profile_factors for "
                         f"'{key}'."

--- a/src/demandlib/particular_profiles.py
+++ b/src/demandlib/particular_profiles.py
@@ -24,16 +24,16 @@ class IndustrialLoadProfile:
         dt_index : pandas.DatetimeIndex
             Datetime index for the load profile.
         holidays : dict
-            Dictionary with keys of type datetime and values with holiday name as str,
-            e.g. {datetime.date(2010, 1, 1): "New year"}. See the
-            electricity_demand_example in the examples directory for information on
-            how to obtain holidays using workalender. Per default, no holidays are
-            used.
+            Dictionary with keys of type datetime and values with holiday name
+            as str, e.g. {datetime.date(2010, 1, 1): "New year"}. See the
+            electricity_demand_example in the examples directory for
+            information on how to obtain holidays using workalender.
+            Per default, no holidays are used.
             Default: None.
         holiday_is_sunday : bool
-            If True, holidays are treated as Sundays. If False, holidays are assigned
-            weekday 0 and separate holiday scaling factors are applied in method
-            simple_profile().
+            If True, holidays are treated as Sundays. If False, holidays are
+            assigned weekday 0 and separate holiday scaling factors are applied
+            in method simple_profile().
             Default: False.
 
         """
@@ -52,28 +52,31 @@ class IndustrialLoadProfile:
         ----------
         annual_demand : float
             Total demand over the period given upon initialisation
-            of IndustrialLoadProfile through parameter `dt_index`. This is actually
-            only the annual demand, if an entire year was given.
+            of IndustrialLoadProfile through parameter `dt_index`. This is
+            actually only the annual demand, if an entire year was given.
 
         Other Parameters
         ----------------
         am : datetime.time
-            Defines the beginning of the workday. Times between `am` and `pm`, including
-            the start and end time defined by `am` and `pm`, are assigned "day" factors
-            from `profile_factors`. Other times are assigned "night" factors.
+            Defines the beginning of the workday. Times between `am` and `pm`,
+            including the start and end time defined by `am` and `pm`, are
+            assigned "day" factors from `profile_factors`. Other times are
+            assigned "night" factors.
             Default: 7 a.m.
         pm : datetime.time
-            Defines the end of the workday. Times between `am` and `pm`, including
-            the start and end time defined by `am` and `pm`, are assigned "day" factors
-            from `profile_factors`. Other times are assigned "night" factors.
+            Defines the end of the workday. Times between `am` and `pm`,
+            including the start and end time defined by `am` and `pm`, are
+            assigned "day" factors from `profile_factors`. Other times are
+            assigned "night" factors.
             Default: 11:30 p.m.
         week : list(int)
             List of weekdays, where 1 corresponds to Monday, 2 to Tuesday, etc.
             Weekdays are assigned "week" factors from `profile_factors`.
             Default: [1, 2, 3, 4, 5].
         weekend : list(int)
-            List of weekend days, where 1 corresponds to Monday, 2 to Tuesday, etc.
-            Weekend days are assigned "weekend" factors from `profile_factors`.
+            List of weekend days, where 1 corresponds to Monday, 2 to Tuesday,
+            etc. Weekend days are assigned "weekend" factors from
+            `profile_factors`.
             Default: [6, 7].
         holiday : list(int)
             List of holiday days. Holidays given upon initialisation of the
@@ -83,9 +86,9 @@ class IndustrialLoadProfile:
             Holidays are assigned "holiday" factors from `profile_factors`.
             Default: [0].
         profile_factors : dict
-            Dictionary with load profile scaling factors for night and day of weekdays,
-            weekend days and holidays. The dictionary must have the same form as the
-            dictionary given as the default value.
+            Dictionary with load profile scaling factors for night and day of
+            weekdays, weekend days and holidays. The dictionary must have the
+            same form as the dictionary given as the default value.
             Default:
             {
                 "week": {"day": 0.8, "night": 0.6},
@@ -97,8 +100,9 @@ class IndustrialLoadProfile:
         -------
         pd.Series
             Series with demand per time step (unit depends on the unit the
-            `annual_demand` was provided with). Index is a DatetimeIndex containing
-            all time steps the IndustrialLoadProfile was initialised with.
+            `annual_demand` was provided with). Index is a DatetimeIndex
+            containing all time steps the IndustrialLoadProfile was initialised
+            with.
 
         """
 
@@ -120,15 +124,19 @@ class IndustrialLoadProfile:
         # check profile factors
         for key in ["week", "weekend", "holiday"]:
             if not key in profile_factors.keys():
-                raise ValueError(f"Missing entry for '{key}' in profile_factors.")
+                raise ValueError(
+                    f"Missing entry for '{key}' in profile_factors."
+                )
             else:
                 if not "day" in profile_factors[key].keys():
                     raise ValueError(
-                        f"Missing entry for 'day' in profile_factors for '{key}'."
+                        f"Missing entry for 'day' in profile_factors for "
+                        f"'{key}'."
                     )
                 elif not "night" in profile_factors[key].keys():
                     raise ValueError(
-                        f"Missing entry for 'night' in profile_factors for '{key}'."
+                        f"Missing entry for 'night' in profile_factors for "
+                        f"'{key}'."
                     )
 
         self.dataframe["ind"] = 0.0
@@ -146,8 +154,8 @@ class IndustrialLoadProfile:
         weekend_filter = self.dataframe["weekday"].isin(weekend)
         holiday_filter = self.dataframe["weekday"].isin(holiday)
 
-        # Update 'ind' column based on day/night filters and weekday/weekend/holiday
-        # conditions
+        # Update 'ind' column based on day/night filters and
+        # weekday/weekend/holiday conditions
         self.dataframe.loc[day_filter & week_filter, "ind"] = \
             profile_factors["week"]["day"]
         self.dataframe.loc[night_filter & week_filter, "ind"] = \

--- a/src/demandlib/particular_profiles.py
+++ b/src/demandlib/particular_profiles.py
@@ -90,11 +90,14 @@ class IndustrialLoadProfile:
             weekdays, weekend days and holidays. The dictionary must have the
             same form as the dictionary given as the default value.
             Default:
-            {
-                "week": {"day": 0.8, "night": 0.6},
-                "weekend": {"day": 0.9, "night": 0.7},
-                "holiday": {"day": 0.9, "night": 0.7},
-            }
+
+            .. code:: python
+
+                {
+                    "week": {"day": 0.8, "night": 0.6},
+                    "weekend": {"day": 0.9, "night": 0.7},
+                    "holiday": {"day": 0.9, "night": 0.7},
+                }
 
         Returns
         -------

--- a/src/demandlib/particular_profiles.py
+++ b/src/demandlib/particular_profiles.py
@@ -132,12 +132,15 @@ class IndustrialLoadProfile:
                     )
 
         self.dataframe["ind"] = 0.0
-        day_mask = self.dataframe.index.indexer_between_time(am, pm)
-        night_mask = self.dataframe.index.indexer_between_time(pm, am)
+
+        day_mask = self.dataframe.index.indexer_between_time(
+            am, pm, include_start=True, include_end=True
+        )
         day_filter = pd.Series(False, index=self.dataframe.index)
         day_filter.iloc[day_mask] = True
-        night_filter = pd.Series(False, index=self.dataframe.index)
-        night_filter.iloc[night_mask] = True
+        # set up night filter as the reverse of the day filter
+        night_filter = pd.Series(True, index=self.dataframe.index)
+        night_filter.iloc[day_mask] = False
 
         week_filter = self.dataframe["weekday"].isin(week)
         weekend_filter = self.dataframe["weekday"].isin(weekend)

--- a/src/demandlib/particular_profiles.py
+++ b/src/demandlib/particular_profiles.py
@@ -62,6 +62,19 @@ class IndustrialLoadProfile:
             "holiday": {"day": 0.9, "night": 0.7},
         }
         profile_factors = kwargs.get("profile_factors", default_factors)
+        # check profile factors
+        for key in ["week", "weekend", "holiday"]:
+            if not key in profile_factors.keys():
+                raise ValueError(f"Missing entry for '{key}' in profile_factors.")
+            else:
+                if not "day" in profile_factors[key].keys():
+                    raise ValueError(
+                        f"Missing entry for 'day' in profile_factors for '{key}'."
+                    )
+                elif not "night" in profile_factors[key].keys():
+                    raise ValueError(
+                        f"Missing entry for 'night' in profile_factors for '{key}'."
+                    )
 
         self.dataframe["ind"] = 0.0
         day_mask = self.dataframe.index.indexer_between_time(am, pm)

--- a/src/demandlib/particular_profiles.py
+++ b/src/demandlib/particular_profiles.py
@@ -178,7 +178,6 @@ class IndustrialLoadProfile:
             profile_factors["holiday"]["night"]
         )
 
-        # Check for NAN values in the dataframe
         if self.dataframe["ind"].isnull().any(axis=0):
             logging.error("NAN value found in industrial load profile")
 

--- a/src/demandlib/particular_profiles.py
+++ b/src/demandlib/particular_profiles.py
@@ -178,9 +178,6 @@ class IndustrialLoadProfile:
             profile_factors["holiday"]["night"]
         )
 
-        if self.dataframe["ind"].isnull().any(axis=0):
-            logging.error("NAN value found in industrial load profile")
-
         time_interval = self.dataframe.index.freq.nanos / 3.6e12
 
         return (

--- a/tests/test_particular_profiles.py
+++ b/tests/test_particular_profiles.py
@@ -35,19 +35,29 @@ class TestIndustrialLoadProfile:
 
         # check factors in self.dataframe["ind"]
         # holiday
-        assert self.ilp.dataframe.at[pd.Timestamp("2010-01-01 6:00"), "ind"] == 0.7
-        assert self.ilp.dataframe.at[pd.Timestamp("2010-01-01 7:00"), "ind"] == 0.9
-        assert self.ilp.dataframe.at[pd.Timestamp("2010-01-01 23:00"), "ind"] == 0.9
+        assert self.ilp.dataframe.at[
+                   pd.Timestamp("2010-01-01 6:00"), "ind"] == 0.7
+        assert self.ilp.dataframe.at[
+                   pd.Timestamp("2010-01-01 7:00"), "ind"] == 0.9
+        assert self.ilp.dataframe.at[
+                   pd.Timestamp("2010-01-01 23:00"), "ind"] == 0.9
         # weekend day
-        assert self.ilp.dataframe.at[pd.Timestamp("2010-01-02 6:00"), "ind"] == 0.7
-        assert self.ilp.dataframe.at[pd.Timestamp("2010-01-02 7:00"), "ind"] == 0.9
-        assert self.ilp.dataframe.at[pd.Timestamp("2010-01-02 23:00"), "ind"] == 0.9
+        assert self.ilp.dataframe.at[
+                   pd.Timestamp("2010-01-02 6:00"), "ind"] == 0.7
+        assert self.ilp.dataframe.at[
+                   pd.Timestamp("2010-01-02 7:00"), "ind"] == 0.9
+        assert self.ilp.dataframe.at[
+                   pd.Timestamp("2010-01-02 23:00"), "ind"] == 0.9
         # week day
-        assert self.ilp.dataframe.at[pd.Timestamp("2010-01-04 6:00"), "ind"] == 0.6
-        assert self.ilp.dataframe.at[pd.Timestamp("2010-01-04 7:00"), "ind"] == 0.8
-        assert self.ilp.dataframe.at[pd.Timestamp("2010-01-04 23:00"), "ind"] == 0.8
+        assert self.ilp.dataframe.at[
+                   pd.Timestamp("2010-01-04 6:00"), "ind"] == 0.6
+        assert self.ilp.dataframe.at[
+                   pd.Timestamp("2010-01-04 7:00"), "ind"] == 0.8
+        assert self.ilp.dataframe.at[
+                   pd.Timestamp("2010-01-04 23:00"), "ind"] == 0.8
 
-        # check sum of factors to make sure not only the tested factors are correct
+        # check sum of factors to make sure not only the tested factors are
+        # correct
         assert np.isclose(self.ilp.dataframe["ind"].sum(), 131.8)
 
         # ############### test with own values ###############
@@ -68,23 +78,36 @@ class TestIndustrialLoadProfile:
 
         # check factors in self.dataframe["ind"]
         # holiday
-        assert self.ilp.dataframe.at[pd.Timestamp("2010-01-01 6:00"), "ind"] == 0.3
-        assert self.ilp.dataframe.at[pd.Timestamp("2010-01-01 7:00"), "ind"] == 0.8
-        assert self.ilp.dataframe.at[pd.Timestamp("2010-01-01 23:00"), "ind"] == 0.3
+        assert self.ilp.dataframe.at[
+                   pd.Timestamp("2010-01-01 6:00"), "ind"] == 0.3
+        assert self.ilp.dataframe.at[
+                   pd.Timestamp("2010-01-01 7:00"), "ind"] == 0.8
+        assert self.ilp.dataframe.at[
+                   pd.Timestamp("2010-01-01 23:00"), "ind"] == 0.3
         # weekend day
-        assert self.ilp.dataframe.at[pd.Timestamp("2010-01-02 6:00"), "ind"] == 0.4
-        assert self.ilp.dataframe.at[pd.Timestamp("2010-01-02 7:00"), "ind"] == 0.7
-        assert self.ilp.dataframe.at[pd.Timestamp("2010-01-02 22:00"), "ind"] == 0.7
+        assert self.ilp.dataframe.at[
+                   pd.Timestamp("2010-01-02 6:00"), "ind"] == 0.4
+        assert self.ilp.dataframe.at[
+                   pd.Timestamp("2010-01-02 7:00"), "ind"] == 0.7
+        assert self.ilp.dataframe.at[
+                   pd.Timestamp("2010-01-02 22:00"), "ind"] == 0.7
         # Monday - now set to be weekend day
-        assert self.ilp.dataframe.at[pd.Timestamp("2010-01-04 6:00"), "ind"] == 0.4
-        assert self.ilp.dataframe.at[pd.Timestamp("2010-01-04 7:00"), "ind"] == 0.7
-        assert self.ilp.dataframe.at[pd.Timestamp("2010-01-04 23:00"), "ind"] == 0.4
+        assert self.ilp.dataframe.at[
+                   pd.Timestamp("2010-01-04 6:00"), "ind"] == 0.4
+        assert self.ilp.dataframe.at[
+                   pd.Timestamp("2010-01-04 7:00"), "ind"] == 0.7
+        assert self.ilp.dataframe.at[
+                   pd.Timestamp("2010-01-04 23:00"), "ind"] == 0.4
         # week day
-        assert self.ilp.dataframe.at[pd.Timestamp("2010-01-05 6:00"), "ind"] == 0.5
-        assert self.ilp.dataframe.at[pd.Timestamp("2010-01-05 7:00"), "ind"] == 0.6
-        assert self.ilp.dataframe.at[pd.Timestamp("2010-01-05 23:00"), "ind"] == 0.5
+        assert self.ilp.dataframe.at[
+                   pd.Timestamp("2010-01-05 6:00"), "ind"] == 0.5
+        assert self.ilp.dataframe.at[
+                   pd.Timestamp("2010-01-05 7:00"), "ind"] == 0.6
+        assert self.ilp.dataframe.at[
+                   pd.Timestamp("2010-01-05 23:00"), "ind"] == 0.5
 
-        # check sum of factors to make sure not only the tested factors are correct
+        # check sum of factors to make sure not only the tested factors are
+        # correct
         assert np.isclose(self.ilp.dataframe["ind"].sum(), 99.2)
 
         # ############### test missing profile factors ###############
@@ -108,7 +131,7 @@ class TestIndustrialLoadProfile:
                 profile_factors=profile_factors,
             )
 
-        # ########### test with default values and holiday_is_sunday = True ###########
+        # ##### test with default values and holiday_is_sunday = True #####
         profile_factors = {
             "week": {"day": 0.6, "night": 0.5},
             "weekend": {"day": 0.7, "night": 0.4},
@@ -120,17 +143,27 @@ class TestIndustrialLoadProfile:
 
         # check factors in self.dataframe["ind"]
         # holiday - now treated as Sunday
-        assert self.ilp_holiday.dataframe.at[pd.Timestamp("2010-01-01 6:00"), "ind"] == 0.4
-        assert self.ilp_holiday.dataframe.at[pd.Timestamp("2010-01-01 7:00"), "ind"] == 0.7
-        assert self.ilp_holiday.dataframe.at[pd.Timestamp("2010-01-01 23:00"), "ind"] == 0.7
+        assert self.ilp_holiday.dataframe.at[
+                   pd.Timestamp("2010-01-01 6:00"), "ind"] == 0.4
+        assert self.ilp_holiday.dataframe.at[
+                   pd.Timestamp("2010-01-01 7:00"), "ind"] == 0.7
+        assert self.ilp_holiday.dataframe.at[
+                   pd.Timestamp("2010-01-01 23:00"), "ind"] == 0.7
         # weekend day
-        assert self.ilp_holiday.dataframe.at[pd.Timestamp("2010-01-02 6:00"), "ind"] == 0.4
-        assert self.ilp_holiday.dataframe.at[pd.Timestamp("2010-01-02 7:00"), "ind"] == 0.7
-        assert self.ilp_holiday.dataframe.at[pd.Timestamp("2010-01-02 23:00"), "ind"] == 0.7
+        assert self.ilp_holiday.dataframe.at[
+                   pd.Timestamp("2010-01-02 6:00"), "ind"] == 0.4
+        assert self.ilp_holiday.dataframe.at[
+                   pd.Timestamp("2010-01-02 7:00"), "ind"] == 0.7
+        assert self.ilp_holiday.dataframe.at[
+                   pd.Timestamp("2010-01-02 23:00"), "ind"] == 0.7
         # week day
-        assert self.ilp_holiday.dataframe.at[pd.Timestamp("2010-01-04 6:00"), "ind"] == 0.5
-        assert self.ilp_holiday.dataframe.at[pd.Timestamp("2010-01-04 7:00"), "ind"] == 0.6
-        assert self.ilp_holiday.dataframe.at[pd.Timestamp("2010-01-04 23:00"), "ind"] == 0.6
+        assert self.ilp_holiday.dataframe.at[
+                   pd.Timestamp("2010-01-04 6:00"), "ind"] == 0.5
+        assert self.ilp_holiday.dataframe.at[
+                   pd.Timestamp("2010-01-04 7:00"), "ind"] == 0.6
+        assert self.ilp_holiday.dataframe.at[
+                   pd.Timestamp("2010-01-04 23:00"), "ind"] == 0.6
 
-        # check sum of factors to make sure not only the tested factors are correct
+        # check sum of factors to make sure not only the tested factors are
+        # correct
         assert np.isclose(self.ilp_holiday.dataframe["ind"].sum(), 98.9)

--- a/tests/test_particular_profiles.py
+++ b/tests/test_particular_profiles.py
@@ -1,0 +1,136 @@
+import datetime
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from demandlib.particular_profiles import IndustrialLoadProfile
+
+
+class TestIndustrialLoadProfile:
+    @classmethod
+    def setup_class(cls):
+        dt_index = pd.date_range(
+            datetime.datetime(2010, 1, 1, 0),
+            periods=24 * 7,
+            freq="1H"
+        )
+        holidays = {
+            datetime.date(2010, 1, 1): "New year",
+        }
+        cls.ilp = IndustrialLoadProfile(
+            dt_index=dt_index,
+            holidays=holidays,
+            holiday_is_sunday=False,
+        )
+        cls.ilp_holiday = IndustrialLoadProfile(
+            dt_index=dt_index,
+            holidays=holidays,
+            holiday_is_sunday=True,
+        )
+
+    def test_simple_profile(self):
+        # ############### test with default values ###############
+        df = self.ilp.simple_profile(1.0)
+
+        # check factors in self.dataframe["ind"]
+        # holiday
+        assert self.ilp.dataframe.at[pd.Timestamp("2010-01-01 6:00"), "ind"] == 0.7
+        assert self.ilp.dataframe.at[pd.Timestamp("2010-01-01 7:00"), "ind"] == 0.9
+        assert self.ilp.dataframe.at[pd.Timestamp("2010-01-01 23:00"), "ind"] == 0.9
+        # weekend day
+        assert self.ilp.dataframe.at[pd.Timestamp("2010-01-02 6:00"), "ind"] == 0.7
+        assert self.ilp.dataframe.at[pd.Timestamp("2010-01-02 7:00"), "ind"] == 0.9
+        assert self.ilp.dataframe.at[pd.Timestamp("2010-01-02 23:00"), "ind"] == 0.9
+        # week day
+        assert self.ilp.dataframe.at[pd.Timestamp("2010-01-04 6:00"), "ind"] == 0.6
+        assert self.ilp.dataframe.at[pd.Timestamp("2010-01-04 7:00"), "ind"] == 0.8
+        assert self.ilp.dataframe.at[pd.Timestamp("2010-01-04 23:00"), "ind"] == 0.8
+
+        # check sum of factors to make sure not only the tested factors are correct
+        assert np.isclose(self.ilp.dataframe["ind"].sum(), 131.8)
+
+        # ############### test with own values ###############
+        profile_factors = {
+            "week": {"day": 0.6, "night": 0.5},
+            "weekend": {"day": 0.7, "night": 0.4},
+            "holiday": {"day": 0.8, "night": 0.3},
+        }
+        week = [2, 3, 4, 5]
+        weekend = [1, 6, 7]
+        df = self.ilp.simple_profile(
+            1.0,
+            week=week, weekend=weekend,
+            profile_factors=profile_factors,
+            am=datetime.time(6, 30, 0),
+            pm=datetime.time(22, 00, 0),
+        )
+
+        # check factors in self.dataframe["ind"]
+        # holiday
+        assert self.ilp.dataframe.at[pd.Timestamp("2010-01-01 6:00"), "ind"] == 0.3
+        assert self.ilp.dataframe.at[pd.Timestamp("2010-01-01 7:00"), "ind"] == 0.8
+        assert self.ilp.dataframe.at[pd.Timestamp("2010-01-01 23:00"), "ind"] == 0.3
+        # weekend day
+        assert self.ilp.dataframe.at[pd.Timestamp("2010-01-02 6:00"), "ind"] == 0.4
+        assert self.ilp.dataframe.at[pd.Timestamp("2010-01-02 7:00"), "ind"] == 0.7
+        assert self.ilp.dataframe.at[pd.Timestamp("2010-01-02 22:00"), "ind"] == 0.7
+        # Monday - now set to be weekend day
+        assert self.ilp.dataframe.at[pd.Timestamp("2010-01-04 6:00"), "ind"] == 0.4
+        assert self.ilp.dataframe.at[pd.Timestamp("2010-01-04 7:00"), "ind"] == 0.7
+        assert self.ilp.dataframe.at[pd.Timestamp("2010-01-04 23:00"), "ind"] == 0.4
+        # week day
+        assert self.ilp.dataframe.at[pd.Timestamp("2010-01-05 6:00"), "ind"] == 0.5
+        assert self.ilp.dataframe.at[pd.Timestamp("2010-01-05 7:00"), "ind"] == 0.6
+        assert self.ilp.dataframe.at[pd.Timestamp("2010-01-05 23:00"), "ind"] == 0.5
+
+        # check sum of factors to make sure not only the tested factors are correct
+        assert np.isclose(self.ilp.dataframe["ind"].sum(), 99.2)
+
+        # ############### test missing profile factors ###############
+        profile_factors = {
+            "week": {"day": 0.6, "night": 0.5},
+        }
+        msg = "Missing entry for 'weekend' in profile_factors."
+        with pytest.raises(ValueError, match=msg):
+            df = self.ilp.simple_profile(
+                1.0,
+                profile_factors=profile_factors,
+            )
+
+        profile_factors = {
+            "week": {"day": 0.6},
+        }
+        msg = "Missing entry for 'night' in profile_factors for 'week'."
+        with pytest.raises(ValueError, match=msg):
+            df = self.ilp.simple_profile(
+                1.0,
+                profile_factors=profile_factors,
+            )
+
+        # ########### test with default values and holiday_is_sunday = True ###########
+        profile_factors = {
+            "week": {"day": 0.6, "night": 0.5},
+            "weekend": {"day": 0.7, "night": 0.4},
+            "holiday": {"day": 0.8, "night": 0.3},
+        }
+        df = self.ilp_holiday.simple_profile(
+            1.0, profile_factors=profile_factors
+        )
+
+        # check factors in self.dataframe["ind"]
+        # holiday - now treated as Sunday
+        assert self.ilp_holiday.dataframe.at[pd.Timestamp("2010-01-01 6:00"), "ind"] == 0.4
+        assert self.ilp_holiday.dataframe.at[pd.Timestamp("2010-01-01 7:00"), "ind"] == 0.7
+        assert self.ilp_holiday.dataframe.at[pd.Timestamp("2010-01-01 23:00"), "ind"] == 0.7
+        # weekend day
+        assert self.ilp_holiday.dataframe.at[pd.Timestamp("2010-01-02 6:00"), "ind"] == 0.4
+        assert self.ilp_holiday.dataframe.at[pd.Timestamp("2010-01-02 7:00"), "ind"] == 0.7
+        assert self.ilp_holiday.dataframe.at[pd.Timestamp("2010-01-02 23:00"), "ind"] == 0.7
+        # week day
+        assert self.ilp_holiday.dataframe.at[pd.Timestamp("2010-01-04 6:00"), "ind"] == 0.5
+        assert self.ilp_holiday.dataframe.at[pd.Timestamp("2010-01-04 7:00"), "ind"] == 0.6
+        assert self.ilp_holiday.dataframe.at[pd.Timestamp("2010-01-04 23:00"), "ind"] == 0.6
+
+        # check sum of factors to make sure not only the tested factors are correct
+        assert np.isclose(self.ilp_holiday.dataframe["ind"].sum(), 98.9)

--- a/tests/test_particular_profiles.py
+++ b/tests/test_particular_profiles.py
@@ -11,9 +11,7 @@ class TestIndustrialLoadProfile:
     @classmethod
     def setup_class(cls):
         dt_index = pd.date_range(
-            datetime.datetime(2010, 1, 1, 0),
-            periods=24 * 7,
-            freq="1H"
+            datetime.datetime(2010, 1, 1, 0), periods=24 * 7, freq="1H"
         )
         holidays = {
             datetime.date(2010, 1, 1): "New year",
@@ -35,26 +33,44 @@ class TestIndustrialLoadProfile:
 
         # check factors in self.dataframe["ind"]
         # holiday
-        assert self.ilp.dataframe.at[
-                   pd.Timestamp("2010-01-01 6:00"), "ind"] == 0.7
-        assert self.ilp.dataframe.at[
-                   pd.Timestamp("2010-01-01 7:00"), "ind"] == 0.9
-        assert self.ilp.dataframe.at[
-                   pd.Timestamp("2010-01-01 23:00"), "ind"] == 0.9
+        assert (
+            self.ilp.dataframe.at[pd.Timestamp("2010-01-01 6:00"), "ind"]
+            == 0.7
+        )
+        assert (
+            self.ilp.dataframe.at[pd.Timestamp("2010-01-01 7:00"), "ind"]
+            == 0.9
+        )
+        assert (
+            self.ilp.dataframe.at[pd.Timestamp("2010-01-01 23:00"), "ind"]
+            == 0.9
+        )
         # weekend day
-        assert self.ilp.dataframe.at[
-                   pd.Timestamp("2010-01-02 6:00"), "ind"] == 0.7
-        assert self.ilp.dataframe.at[
-                   pd.Timestamp("2010-01-02 7:00"), "ind"] == 0.9
-        assert self.ilp.dataframe.at[
-                   pd.Timestamp("2010-01-02 23:00"), "ind"] == 0.9
+        assert (
+            self.ilp.dataframe.at[pd.Timestamp("2010-01-02 6:00"), "ind"]
+            == 0.7
+        )
+        assert (
+            self.ilp.dataframe.at[pd.Timestamp("2010-01-02 7:00"), "ind"]
+            == 0.9
+        )
+        assert (
+            self.ilp.dataframe.at[pd.Timestamp("2010-01-02 23:00"), "ind"]
+            == 0.9
+        )
         # week day
-        assert self.ilp.dataframe.at[
-                   pd.Timestamp("2010-01-04 6:00"), "ind"] == 0.6
-        assert self.ilp.dataframe.at[
-                   pd.Timestamp("2010-01-04 7:00"), "ind"] == 0.8
-        assert self.ilp.dataframe.at[
-                   pd.Timestamp("2010-01-04 23:00"), "ind"] == 0.8
+        assert (
+            self.ilp.dataframe.at[pd.Timestamp("2010-01-04 6:00"), "ind"]
+            == 0.6
+        )
+        assert (
+            self.ilp.dataframe.at[pd.Timestamp("2010-01-04 7:00"), "ind"]
+            == 0.8
+        )
+        assert (
+            self.ilp.dataframe.at[pd.Timestamp("2010-01-04 23:00"), "ind"]
+            == 0.8
+        )
 
         # check sum of factors to make sure not only the tested factors are
         # correct
@@ -72,7 +88,8 @@ class TestIndustrialLoadProfile:
         weekend = [1, 6, 7]
         df = self.ilp.simple_profile(
             1.0,
-            week=week, weekend=weekend,
+            week=week,
+            weekend=weekend,
             profile_factors=profile_factors,
             am=datetime.time(6, 30, 0),
             pm=datetime.time(22, 00, 0),
@@ -80,33 +97,57 @@ class TestIndustrialLoadProfile:
 
         # check factors in self.dataframe["ind"]
         # holiday
-        assert self.ilp.dataframe.at[
-                   pd.Timestamp("2010-01-01 6:00"), "ind"] == 0.3
-        assert self.ilp.dataframe.at[
-                   pd.Timestamp("2010-01-01 7:00"), "ind"] == 0.8
-        assert self.ilp.dataframe.at[
-                   pd.Timestamp("2010-01-01 23:00"), "ind"] == 0.3
+        assert (
+            self.ilp.dataframe.at[pd.Timestamp("2010-01-01 6:00"), "ind"]
+            == 0.3
+        )
+        assert (
+            self.ilp.dataframe.at[pd.Timestamp("2010-01-01 7:00"), "ind"]
+            == 0.8
+        )
+        assert (
+            self.ilp.dataframe.at[pd.Timestamp("2010-01-01 23:00"), "ind"]
+            == 0.3
+        )
         # weekend day
-        assert self.ilp.dataframe.at[
-                   pd.Timestamp("2010-01-02 6:00"), "ind"] == 0.4
-        assert self.ilp.dataframe.at[
-                   pd.Timestamp("2010-01-02 7:00"), "ind"] == 0.7
-        assert self.ilp.dataframe.at[
-                   pd.Timestamp("2010-01-02 22:00"), "ind"] == 0.7
+        assert (
+            self.ilp.dataframe.at[pd.Timestamp("2010-01-02 6:00"), "ind"]
+            == 0.4
+        )
+        assert (
+            self.ilp.dataframe.at[pd.Timestamp("2010-01-02 7:00"), "ind"]
+            == 0.7
+        )
+        assert (
+            self.ilp.dataframe.at[pd.Timestamp("2010-01-02 22:00"), "ind"]
+            == 0.7
+        )
         # Monday - now set to be weekend day
-        assert self.ilp.dataframe.at[
-                   pd.Timestamp("2010-01-04 6:00"), "ind"] == 0.4
-        assert self.ilp.dataframe.at[
-                   pd.Timestamp("2010-01-04 7:00"), "ind"] == 0.7
-        assert self.ilp.dataframe.at[
-                   pd.Timestamp("2010-01-04 23:00"), "ind"] == 0.4
+        assert (
+            self.ilp.dataframe.at[pd.Timestamp("2010-01-04 6:00"), "ind"]
+            == 0.4
+        )
+        assert (
+            self.ilp.dataframe.at[pd.Timestamp("2010-01-04 7:00"), "ind"]
+            == 0.7
+        )
+        assert (
+            self.ilp.dataframe.at[pd.Timestamp("2010-01-04 23:00"), "ind"]
+            == 0.4
+        )
         # week day
-        assert self.ilp.dataframe.at[
-                   pd.Timestamp("2010-01-05 6:00"), "ind"] == 0.5
-        assert self.ilp.dataframe.at[
-                   pd.Timestamp("2010-01-05 7:00"), "ind"] == 0.6
-        assert self.ilp.dataframe.at[
-                   pd.Timestamp("2010-01-05 23:00"), "ind"] == 0.5
+        assert (
+            self.ilp.dataframe.at[pd.Timestamp("2010-01-05 6:00"), "ind"]
+            == 0.5
+        )
+        assert (
+            self.ilp.dataframe.at[pd.Timestamp("2010-01-05 7:00"), "ind"]
+            == 0.6
+        )
+        assert (
+            self.ilp.dataframe.at[pd.Timestamp("2010-01-05 23:00"), "ind"]
+            == 0.5
+        )
 
         # check sum of factors to make sure not only the tested factors are
         # correct
@@ -147,26 +188,62 @@ class TestIndustrialLoadProfile:
 
         # check factors in self.dataframe["ind"]
         # holiday - now treated as Sunday
-        assert self.ilp_holiday.dataframe.at[
-                   pd.Timestamp("2010-01-01 6:00"), "ind"] == 0.4
-        assert self.ilp_holiday.dataframe.at[
-                   pd.Timestamp("2010-01-01 7:00"), "ind"] == 0.7
-        assert self.ilp_holiday.dataframe.at[
-                   pd.Timestamp("2010-01-01 23:00"), "ind"] == 0.7
+        assert (
+            self.ilp_holiday.dataframe.at[
+                pd.Timestamp("2010-01-01 6:00"), "ind"
+            ]
+            == 0.4
+        )
+        assert (
+            self.ilp_holiday.dataframe.at[
+                pd.Timestamp("2010-01-01 7:00"), "ind"
+            ]
+            == 0.7
+        )
+        assert (
+            self.ilp_holiday.dataframe.at[
+                pd.Timestamp("2010-01-01 23:00"), "ind"
+            ]
+            == 0.7
+        )
         # weekend day
-        assert self.ilp_holiday.dataframe.at[
-                   pd.Timestamp("2010-01-02 6:00"), "ind"] == 0.4
-        assert self.ilp_holiday.dataframe.at[
-                   pd.Timestamp("2010-01-02 7:00"), "ind"] == 0.7
-        assert self.ilp_holiday.dataframe.at[
-                   pd.Timestamp("2010-01-02 23:00"), "ind"] == 0.7
+        assert (
+            self.ilp_holiday.dataframe.at[
+                pd.Timestamp("2010-01-02 6:00"), "ind"
+            ]
+            == 0.4
+        )
+        assert (
+            self.ilp_holiday.dataframe.at[
+                pd.Timestamp("2010-01-02 7:00"), "ind"
+            ]
+            == 0.7
+        )
+        assert (
+            self.ilp_holiday.dataframe.at[
+                pd.Timestamp("2010-01-02 23:00"), "ind"
+            ]
+            == 0.7
+        )
         # week day
-        assert self.ilp_holiday.dataframe.at[
-                   pd.Timestamp("2010-01-04 6:00"), "ind"] == 0.5
-        assert self.ilp_holiday.dataframe.at[
-                   pd.Timestamp("2010-01-04 7:00"), "ind"] == 0.6
-        assert self.ilp_holiday.dataframe.at[
-                   pd.Timestamp("2010-01-04 23:00"), "ind"] == 0.6
+        assert (
+            self.ilp_holiday.dataframe.at[
+                pd.Timestamp("2010-01-04 6:00"), "ind"
+            ]
+            == 0.5
+        )
+        assert (
+            self.ilp_holiday.dataframe.at[
+                pd.Timestamp("2010-01-04 7:00"), "ind"
+            ]
+            == 0.6
+        )
+        assert (
+            self.ilp_holiday.dataframe.at[
+                pd.Timestamp("2010-01-04 23:00"), "ind"
+            ]
+            == 0.6
+        )
 
         # check sum of factors to make sure not only the tested factors are
         # correct

--- a/tests/test_particular_profiles.py
+++ b/tests/test_particular_profiles.py
@@ -76,7 +76,9 @@ class TestIndustrialLoadProfile:
         )
 
         # check sum of factors to make sure not only the tested factors are
-        # correct
+        # correct - the factors don't add up to 100 but to some number that
+        # depends on the given profile factors and time steps; as long as
+        # these don't change the number checked here should not change either
         assert np.isclose(self.ilp.dataframe["ind"].sum(), 131.8)
         # check total demand
         assert np.isclose(df.sum(), 1.0)
@@ -157,7 +159,9 @@ class TestIndustrialLoadProfile:
         )
 
         # check sum of factors to make sure not only the tested factors are
-        # correct
+        # correct - the factors don't add up to 100 but to some number that
+        # depends on the given profile factors and time steps; as long as
+        # these don't change the number checked here should not change either
         assert np.isclose(self.ilp.dataframe["ind"].sum(), 99.2)
         # check total demand
         assert np.isclose(df.sum(), 1.0)
@@ -261,7 +265,9 @@ class TestIndustrialLoadProfile:
         )
 
         # check sum of factors to make sure not only the tested factors are
-        # correct
+        # correct - the factors don't add up to 100 but to some number that
+        # depends on the given profile factors and time steps; as long as
+        # these don't change the number checked here should not change either
         assert np.isclose(self.ilp_holiday.dataframe["ind"].sum(), 98.9)
         # check total demand
         assert np.isclose(df.sum(), 1.0)

--- a/tests/test_particular_profiles.py
+++ b/tests/test_particular_profiles.py
@@ -172,7 +172,7 @@ class TestIndustrialLoadProfile:
         }
         msg = "Missing entry for 'weekend' in profile_factors."
         with pytest.raises(ValueError, match=msg):
-            df = self.ilp.simple_profile(
+            self.ilp.simple_profile(
                 1.0,
                 profile_factors=profile_factors,
             )
@@ -182,7 +182,7 @@ class TestIndustrialLoadProfile:
         }
         msg = "Missing entry for 'night' in profile_factors for 'week'."
         with pytest.raises(ValueError, match=msg):
-            df = self.ilp.simple_profile(
+            self.ilp.simple_profile(
                 1.0,
                 profile_factors=profile_factors,
             )

--- a/tests/test_particular_profiles.py
+++ b/tests/test_particular_profiles.py
@@ -27,8 +27,11 @@ class TestIndustrialLoadProfile:
             holiday_is_sunday=True,
         )
 
-    def test_simple_profile(self):
-        # ############### test with default values ###############
+    def test_simple_profile_default_values(self):
+        """
+        test with default values
+
+        """
         df = self.ilp.simple_profile(1.0)
 
         # check factors in self.dataframe["ind"]
@@ -78,7 +81,11 @@ class TestIndustrialLoadProfile:
         # check total demand
         assert np.isclose(df.sum(), 1.0)
 
-        # ############### test with own values ###############
+    def test_simple_profile_own_values(self):
+        """
+        test with own values
+
+        """
         profile_factors = {
             "week": {"day": 0.6, "night": 0.5},
             "weekend": {"day": 0.7, "night": 0.4},
@@ -155,7 +162,11 @@ class TestIndustrialLoadProfile:
         # check total demand
         assert np.isclose(df.sum(), 1.0)
 
-        # ############### test missing profile factors ###############
+    def test_simple_profile_error_raising(self):
+        """
+        test error raising in case of missing profile factors
+
+        """
         profile_factors = {
             "week": {"day": 0.6, "night": 0.5},
         }
@@ -176,7 +187,11 @@ class TestIndustrialLoadProfile:
                 profile_factors=profile_factors,
             )
 
-        # ##### test with default values and holiday_is_sunday = True #####
+    def test_simple_profile_holiday_is_sunday(self):
+        """
+        test with default values and holiday_is_sunday = True
+
+        """
         profile_factors = {
             "week": {"day": 0.6, "night": 0.5},
             "weekend": {"day": 0.7, "night": 0.4},

--- a/tests/test_particular_profiles.py
+++ b/tests/test_particular_profiles.py
@@ -59,6 +59,8 @@ class TestIndustrialLoadProfile:
         # check sum of factors to make sure not only the tested factors are
         # correct
         assert np.isclose(self.ilp.dataframe["ind"].sum(), 131.8)
+        # check total demand
+        assert np.isclose(df.sum(), 1.0)
 
         # ############### test with own values ###############
         profile_factors = {
@@ -109,6 +111,8 @@ class TestIndustrialLoadProfile:
         # check sum of factors to make sure not only the tested factors are
         # correct
         assert np.isclose(self.ilp.dataframe["ind"].sum(), 99.2)
+        # check total demand
+        assert np.isclose(df.sum(), 1.0)
 
         # ############### test missing profile factors ###############
         profile_factors = {
@@ -167,3 +171,5 @@ class TestIndustrialLoadProfile:
         # check sum of factors to make sure not only the tested factors are
         # correct
         assert np.isclose(self.ilp_holiday.dataframe["ind"].sum(), 98.9)
+        # check total demand
+        assert np.isclose(df.sum(), 1.0)


### PR DESCRIPTION
* Describe your pull request as transparent as possible
  * I created a new PR to address the issue raised in PR #60 that holiday factors should be used for holidays when setting up the industrial step load profile. I made a new one instead of building upon the existing one, because there were several issues that made it easier to start from scratch:
    * PR #60 would have reintroduced the bug fixed in #66, wherefore major changes to the proposed changes were necessary.
    * The holiday scaling factors that were added in PR #60 were not used correctly, as instead the weekend scaling factors were mistakenly used.
    * PR #60 further suggested that the electricity_demand_example.py is incorrect, which is not the case. I therefore ignored the proposed changes there.
    * Tox failed in PR #60.
  * PR #60 was still helpful and I built upon the suggestions for the usage of separate holiday factors and used the example on how to use the industrial load profile.

