### PR TITLE
Fix 'incompatible dtype' FutureWarning in pandas 2.2.1

### DIFF
--- a/src/demandlib/bdew/elec_slp.py
+++ b/src/demandlib/bdew/elec_slp.py
@@ -116,9 +116,9 @@ class ElecSlp:
             new_df, holidays=holidays, holiday_is_sunday=True
         )
 
-        new_df["hour"] = dt_index.hour.astype(int)
-        new_df["weekday"] = new_df["weekday"].astype(int)
-        new_df["minute"] = dt_index.minute.astype(int)
+        new_df["hour"] = dt_index.hour.astype('int64')
+        new_df["weekday"] = new_df["weekday"].astype('int64')
+        new_df["minute"] = dt_index.minute.astype('int64')
         time_df = new_df[["date", "hour", "minute", "weekday"]].copy()
         tmp_df[slp_types] = tmp_df[slp_types].astype(float)
 

--- a/src/demandlib/bdew/elec_slp.py
+++ b/src/demandlib/bdew/elec_slp.py
@@ -116,9 +116,9 @@ class ElecSlp:
             new_df, holidays=holidays, holiday_is_sunday=True
         )
 
-        new_df["hour"] = dt_index.hour.astype('int64')
-        new_df["weekday"] = new_df["weekday"].astype('int64')
-        new_df["minute"] = dt_index.minute.astype('int64')
+        new_df["hour"] = dt_index.hour.astype("int64")
+        new_df["weekday"] = new_df["weekday"].astype("int64")
+        new_df["minute"] = dt_index.minute.astype("int64")
         time_df = new_df[["date", "hour", "minute", "weekday"]].copy()
         tmp_df[slp_types] = tmp_df[slp_types].astype(float)
 

--- a/src/demandlib/tools.py
+++ b/src/demandlib/tools.py
@@ -1,5 +1,4 @@
-"""Tools needed by the main classes
-"""
+"""Tools needed by the main classes."""
 
 import pandas as pd
 


### PR DESCRIPTION
Changing the dtype to ``int64`` fixes several pandas FutureWarnings.

Fixes #71

