### PR TITLE
Allow retrieving only warm water profile

### DIFF
--- a/src/demandlib/bdew/heat_building.py
+++ b/src/demandlib/bdew/heat_building.py
@@ -47,6 +47,8 @@ class HeatBuilding:
         wind classification for building location (0=not windy or 1=windy)
     ww_incl : boolean
         decider whether warm water load is included in the heat load profile
+    ww_only : boolean
+        if true, only warm water load is included in the heat load profile
     """
 
     def __init__(self, df_index, **kwargs):
@@ -71,6 +73,7 @@ class HeatBuilding:
                 "Building class must be 0 for non-residential buildings"
             )
         self.ww_incl = kwargs.get("ww_incl", True)
+        self.ww_only = kwargs.get("ww_only", False)
         self.name = kwargs.get("name", self.shlp_type)
 
     def weighted_temperature(self, how="geometric_series"):
@@ -293,10 +296,14 @@ class HeatBuilding:
         a = sigmoid["parameter_a"].iloc[0]
         b = sigmoid["parameter_b"].iloc[0]
         c = sigmoid["parameter_c"].iloc[0]
-        if self.ww_incl:
+        if self.ww_incl or self.ww_only:
             d = sigmoid["parameter_d"].iloc[0]
         else:
             d = 0
+
+        if self.ww_only:  # Get only the warm water profile
+            a = b = c = 0
+
         return a, b, c, d
 
     def get_weekday_parameters(self, filename="shlp_weekday_factors.csv"):

--- a/tests/test_particular_profiles.py
+++ b/tests/test_particular_profiles.py
@@ -4,8 +4,8 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from demandlib.particular_profiles import IndustrialLoadProfile
 from demandlib.bdew.heat_building import HeatBuilding
+from demandlib.particular_profiles import IndustrialLoadProfile
 
 
 class TestIndustrialLoadProfile:

--- a/tests/test_particular_profiles.py
+++ b/tests/test_particular_profiles.py
@@ -274,30 +274,27 @@ class TestIndustrialLoadProfile:
         assert np.isclose(df.sum(), 1.0)
 
 
-class TestHeatBuilding:
-    @classmethod
-    def setup_class(cls):
-        dt_index = pd.date_range(
-            datetime.datetime(2010, 1, 1, 0), periods=24 * 7, freq="1h"
-        )
-        cls.heat_building = HeatBuilding(
-            df_index=dt_index,
-            temperature=pd.Series([15] * len(dt_index)),
-            annual_heat_demand=10000,
-            shlp_type="EFH",
-            wind_class=0,
-            building_class=1,
-            ww_only=True,  # Set the tested attribute
-        )
+def test_ww_only_sigmoid_parameters():
+    """
+    Test HeatBuilding sigmoid parameters with ww_only flag set to True
+    """
+    dt_index = pd.date_range(
+        datetime.datetime(2010, 1, 1, 0), periods=24 * 7, freq="1h"
+    )
+    heat_building = HeatBuilding(
+        df_index=dt_index,
+        temperature=pd.Series([15] * len(dt_index)),
+        annual_heat_demand=10000,
+        shlp_type="EFH",
+        wind_class=0,
+        building_class=1,
+        ww_only=True,  # Set the tested attribute
+    )
 
-    def test_ww_only_sigmoid_parameters(self):
-        """
-        Test sigmoid parameters with ww_only flag set to True
-        """
-        a, b, c, d = self.heat_building.get_sigmoid_parameters()
-        assert a == 0
-        assert b == 0
-        assert c == 0
-        assert (
-            d != 0
-        )  # Ensure d is not zero as it should be the only parameter used
+    a, b, c, d = heat_building.get_sigmoid_parameters()
+    assert a == 0
+    assert b == 0
+    assert c == 0
+    assert (
+        d != 0
+    )  # Ensure d is not zero as it should be the only parameter used

--- a/tests/test_particular_profiles.py
+++ b/tests/test_particular_profiles.py
@@ -5,6 +5,7 @@ import pandas as pd
 import pytest
 
 from demandlib.particular_profiles import IndustrialLoadProfile
+from demandlib.bdew.heat_building import HeatBuilding
 
 
 class TestIndustrialLoadProfile:
@@ -271,3 +272,30 @@ class TestIndustrialLoadProfile:
         assert np.isclose(self.ilp_holiday.dataframe["ind"].sum(), 98.9)
         # check total demand
         assert np.isclose(df.sum(), 1.0)
+
+
+class TestHeatBuilding:
+    @classmethod
+    def setup_class(cls):
+        dt_index = pd.date_range(
+            datetime.datetime(2010, 1, 1, 0), periods=24 * 7, freq="1h"
+        )
+        cls.heat_building = HeatBuilding(
+            df_index=dt_index,
+            temperature=pd.Series([15] * len(dt_index)),
+            annual_heat_demand=10000,
+            shlp_type="EFH",
+            wind_class=0,
+            building_class=1,
+            ww_only=True  # Set the new attribute
+        )
+
+    def test_ww_only_sigmoid_parameters(self):
+        """
+        Test sigmoid parameters with ww_only flag set to True
+        """
+        a, b, c, d = self.heat_building.get_sigmoid_parameters()
+        assert a == 0
+        assert b == 0
+        assert c == 0
+        assert d != 0  # Ensure d is not zero as it should be the only parameter used

--- a/tests/test_particular_profiles.py
+++ b/tests/test_particular_profiles.py
@@ -287,7 +287,7 @@ class TestHeatBuilding:
             shlp_type="EFH",
             wind_class=0,
             building_class=1,
-            ww_only=True  # Set the new attribute
+            ww_only=True,  # Set the tested attribute
         )
 
     def test_ww_only_sigmoid_parameters(self):
@@ -298,4 +298,6 @@ class TestHeatBuilding:
         assert a == 0
         assert b == 0
         assert c == 0
-        assert d != 0  # Ensure d is not zero as it should be the only parameter used
+        assert (
+            d != 0
+        )  # Ensure d is not zero as it should be the only parameter used


### PR DESCRIPTION
I added a new argument to ``HeatBuilding()``:

> ww_only : boolean
>         if true, only warm water load is included in the heat load profile

This causes only the warm water profile to be returned, by setting the sigmoid parameters a, b and c to 0 and only keeping parameter d.

Fixes #73
Fixes #59