### PR TITLE
Make temperature limit parameters actually optional

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,8 @@ New features
 
 Bug fixes
 #########
+*   Implement default temperature limits for VDI 4655 calculation to make
+    ``summer_temperature_limit`` and ``winter_temperature_limit`` optional
 
 Other changes
 #############

--- a/src/demandlib/vdi/regions.py
+++ b/src/demandlib/vdi/regions.py
@@ -603,8 +603,8 @@ class Region:
         for house in self.houses:
             t_limit = namedtuple("temperature_limit", "summer winter")
             tl = t_limit(
-                summer=house["summer_temperature_limit"],
-                winter=house["winter_temperature_limit"],
+                summer=house.get("summer_temperature_limit", 15),
+                winter=house.get("winter_temperature_limit", 5),
             )
             df_typ = (
                 self.type_days[tl]


### PR DESCRIPTION
This PR provides a fix that was, from my understanding, determined as fine in PR #76.
- The default temperatures are defined in the norm
- The temperature limits are defined two times in the script. In the other place, the defaults were already implemented. So this is only consequential