### PR TITLE
Fix leap year handling in VDI

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ New features
 
 Bug fixes
 #########
+*   Fix leap year handling in VDI 4655 profiles
 
 Other changes
 #############

--- a/src/demandlib/vdi/regions.py
+++ b/src/demandlib/vdi/regions.py
@@ -343,7 +343,7 @@ class Region:
         # Create a table for every minute of the year
         minute_table = pd.DataFrame(
             index=pd.date_range(
-                f"1/1/{self._year}", periods=525600, freq="Min"
+                f"1/1/{self._year}", periods=self.hoy * 60, freq="Min"
             )
         )
 

--- a/tests/test_vdi4655.py
+++ b/tests/test_vdi4655.py
@@ -105,15 +105,25 @@ class TestVDI4655Profiles:
         # Quarter-hourly data should have 4 times as many entries
         assert len(load_curves_quarter) == len(load_curves_hourly) * 4
 
-    def test_leap_year(self):
-        """Test handling of leap years."""
-        # region_leap = Region(2020, try_region=4)  # Leap year
-        region_normal = Region(
-            2017, Climate().from_try_data(4)
-        )  # Non-leap year
+    def test_leap_year(self, example_houses, example_holidays):
+        """Test generation of load curves for leap year."""
+        climate = Climate().from_try_data(4)
+        climate.temperature = pd.concat(
+            [climate.temperature, climate.temperature.iloc[[-1]]]
+        )
+        climate.cloud_coverage = pd.concat(
+            [climate.cloud_coverage, climate.cloud_coverage.iloc[[-1]]]
+        )
 
-        # assert region_leap.hoy == 8784  # Hours in leap year
-        assert region_normal.hoy == 8760  # Hours in normal year
+        region = Region(
+            2024,
+            climate=climate,
+            houses=example_houses,
+            holidays=example_holidays,
+            resample_rule="1h",
+        )
+        load_curves = region.get_load_curve_houses()
+        assert len(load_curves) == 8784  # 366 days * 24 hours
 
     def test_temperature_limits(self, example_houses):
         """Test custom temperature limits."""


### PR DESCRIPTION
A hardcoded number of minutes per year prevented leap years from being constructed properly. This is fixed by using the ``hoy``. Also there was a test ``test_leap_year()``, but it did not actually test a leap year.
This should fix those issues.