### PR TITLE
Fix VDI4655 docs

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -5,6 +5,7 @@ Authors
 (alphabetic order)
 
 * Amedeo Ceruti
+* Benjamin Singh
 * Birgit Schachler
 * Caroline Möller
 * Florian Maurer

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,8 @@ Bug fixes
 Other changes
 #############
 
+* Documentation improvements.
+
 
 v0.2.2 (2025-04-09)
 +++++++++++++++++++++++++
@@ -42,7 +44,7 @@ v0.2.0 (2024-06-27)
 
 Bug fixes
 #########
-*   Raise error for non supported shlp_type 
+*   Raise error for non supported shlp_type
 	in non-commercial buildings
 
 Other changes

--- a/docs/vdi4655.rst
+++ b/docs/vdi4655.rst
@@ -36,13 +36,15 @@ Here's a basic example of how to use the VDI 4655 module::
             "Q_Heiz_a": 6000,
             "Q_TWW_a": 1500,
             "W_a": 5250,
+            "summer_temperature_limit": 15,
+            "winter_temperature_limit": 5,
         }
     ]
 
     # Create region
     region = vdi.Region(
         2017,
-        try_region=4,
+        climate=vdi.Climate().from_try_data(try_region=4),
         houses=houses,
         resample_rule="1h"
     )


### PR DESCRIPTION
The VDI4655 code example in the documentation is not working with the current version of `demandlib` (`v2.2.0`). There are two reasons for this:

1. The `house` dictionary requires the `summer_temperature_limit` and `winter_temperature_limit` entries to be set in order to run the example. When these entries are not set, a `KeyError` is raised. Even if they become optional again in the future (I saw a change in another commit), it probably doesn't hurt to include them in the code example.

2. The `vdi.Region()` constructor no longer accepts a `try_region` parameter. It seems that `climate` is used instead.

These changes make the example executable again.
