### PR TITLE
Replace coveralls by GH workflow

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,7 +5,7 @@ source = src
 branch = true
 source =
     src
-    tests
+relative_files = true
 parallel = true
 
 [report]

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,36 @@
+# Additional copyright: Joachim Jablon, kieferro (MIT license)
+name: Post coverage comment
+
+on:
+  workflow_run:
+    workflows: ["tox pytests"]
+    types:
+      - completed
+
+jobs:
+  test:
+    name: Run tests & display coverage
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    permissions:
+      # Gives the action the necessary permissions for publishing new
+      # comments in pull requests.
+      pull-requests: write
+      # Gives the action the necessary permissions for editing existing
+      # comments (to avoid publishing multiple comments in the same PR)
+      contents: write
+      # Gives the action the necessary permissions for looking up the
+      # workflow that launched this workflow, and download the related
+      # artifact that contains the comment to be published
+      actions: read
+    steps:
+      # DO NOT run actions/checkout here, for security reasons
+      # For details, refer to https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+      - name: Post comment
+        uses: py-cov-action/python-coverage-comment-action@v3
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_PR_RUN_ID: ${{ github.event.workflow_run.id }}
+          # Update those if you changed the default values:
+          # COMMENT_ARTIFACT_NAME: python-coverage-comment-action
+          # COMMENT_FILENAME: python-coverage-comment-action.txt

--- a/.github/workflows/tox_pytests.yml
+++ b/.github/workflows/tox_pytests.yml
@@ -1,3 +1,4 @@
+# Additional copyright: Joachim Jablon, kieferro (MIT license)
 name: tox pytests
 
 on:
@@ -27,15 +28,64 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install tox tox-gh-actions coverage coveralls
+        python -m pip install tox tox-gh-actions coverage
     - name: Test with tox
       run: tox
+      env:
+        COVERAGE_FILE: ".coverage.${{ matrix.python-version }}"
+        # The file name prefix must be ".coverage." for "coverage combine"
+        # enabled by "MERGE_COVERAGE_FILES: true" to work. A "subprocess"
+        # error with the message "No data to combine" will be triggered if
+        # this prefix is not used.
 
     - name: Check test coverage
-      run: coverage report -m --fail-under=${{ matrix.vcs == 'bzr' && 84 || 85 }}
-
-    - name: Report to coveralls
-      run: coveralls
+      run: coverage report -m --fail-under=85
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        COVERALLS_SERVICE_NAME: github
+        COVERAGE_FILE: ".coverage.${{ matrix.python-version }}"
+
+    - name: Store coverage file
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-${{ matrix.python-version }}
+        path: .coverage.${{ matrix.python-version }}
+        # By default hidden files/folders (i.e. starting with .) are ignored.
+        # You may prefer (for security reasons) not setting this and instead
+        # set COVERAGE_FILE above to not start with a `.`, but you cannot
+        # use "MERGE_COVERAGE_FILES: true" later on and need to manually
+        # combine the coverage file using "pipx run coverage combine"
+        include-hidden-files: true
+
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    needs: pytest
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # This is optional since by default it's to true. The git
+          # operations in python-coverage-comment-action utilize the token
+          # stored by actions/checkout.
+          persist-credentials: true
+
+      - uses: actions/download-artifact@v4
+        id: download
+        with:
+          pattern: coverage-*
+          merge-multiple: true
+
+      - name: Coverage comment
+        id: coverage_comment
+        uses: py-cov-action/python-coverage-comment-action@v3
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MERGE_COVERAGE_FILES: true
+
+      - name: Store Pull Request comment to be posted
+        uses: actions/upload-artifact@v4
+        if: steps.coverage_comment.outputs.COMMENT_FILE_WRITTEN == 'true'
+        with:
+          name: python-coverage-comment-action
+          path: python-coverage-comment-action.txt

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ Overview
     * - docs
       - |docs|
     * - tests
-      - | |tox-pytest| |tox-checks| |coveralls|
+      - | |tox-pytest| |tox-checks|
     * - package
       - | |version| |wheel| |supported-versions| |supported-implementations| |commits-since| |packaging|
 
@@ -27,10 +27,6 @@ Overview
 .. |docs| image:: https://readthedocs.org/projects/oemof-demand/badge/?style=flat
     :target: https://oemof-demand.readthedocs.io/
     :alt: Documentation Status
-
-.. |coveralls| image:: https://coveralls.io/repos/oemof/oemof-demand/badge.svg?branch=dev&service=github
-    :alt: Coverage Status
-    :target: https://coveralls.io/github/oemof/oemof-demand?branch=dev
 
 .. |version| image:: https://img.shields.io/pypi/v/oemof-demand.svg
     :alt: PyPI Package latest release


### PR DESCRIPTION
Often, our CI tests fail just because coveralls is unreachable. The last outage was just the longest one. A second argument is, that CI tests should just make sure that local tests were run. If local tests pass, CI tests should also pass. With Coveralls, this is no longer the case. Thirdly, we often wave through merges even if coverage decreases. The reason is simple: If code is re-factored so that lines of code can be reduced (and tested lines are removed), often also nominal coverage decreases. Thus, the coverage (change) only has informative character anyway.

Concluding, I think it makes sense to remove coveralls from the CI pipeline. (I still like to have the coverage information accessible, nonetheless.)

(Description from https://github.com/oemof/oemof-network/pull/79.)