### PR TITLE
Fix warning to error escalation bug

### DIFF
--- a/src/oemof/demand/bdew/elec_slp.py
+++ b/src/oemof/demand/bdew/elec_slp.py
@@ -167,9 +167,6 @@ class ElecSlp:
         left_cols = ["hour_of_day", "minute_of_hour", "weekday"]
         right_cols = ["hour", "minute", "weekday"]
         tmp_df = tmp_df.reset_index(drop=True)
-        import warnings
-
-        warnings.simplefilter("error")
 
         for p in self._seasons.keys():
             a = datetime.datetime(


### PR DESCRIPTION
There was a bug that would turn any warning produced after instantiating ``ElecSlp`` into an error. I just removed two lines, that I am guessing were put there for debugging reasons and accidentally left there.

Simple example to reproduce the bug:
```python
import warnings
from oemof.demand import bdew

warnings.warn('I am a warning')

bdew.ElecSlp(year=2026)

warnings.warn('I am an error')
```